### PR TITLE
Fix walking-distance fallback to use haversine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ pnpm-debug.log*
 
 # Vite / build output
 dist/
+build/
 
 # TypeScript
 *.tsbuildinfo

--- a/src/logic/routing.ts
+++ b/src/logic/routing.ts
@@ -1,6 +1,8 @@
 // Lightweight walking routing via OSRM public demo (for development).
 // For production, use your own OSRM/Valhalla/Mapbox/ORS backend.
 
+import { haversine } from './distance';
+
 export type LatLon = [number, number];
 
 export async function getWalkingRouteOSRM(from: LatLon, to: LatLon): Promise<LatLon[] | null> {
@@ -62,15 +64,15 @@ export async function findClosestStopByWalking(point: LatLon, stops: LatLon[], k
   }
 
   if (best) return best;
-  // Fallback to straight line nearest
+  // Fallback to straight-line distance using haversine formula
   let minI = 0;
   let minD = Infinity;
   stops.forEach((c, i) => {
-    const d = (point[0] - c[0]) ** 2 + (point[1] - c[1]) ** 2;
+    const d = haversine(point, c);
     if (d < minD) {
       minD = d;
       minI = i;
     }
   });
-  return { index: minI, coord: stops[minI], distanceMeters: Math.sqrt(minD) };
+  return { index: minI, coord: stops[minI], distanceMeters: minD };
 }

--- a/tests/routing.test.cjs
+++ b/tests/routing.test.cjs
@@ -1,0 +1,45 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const ts = require('typescript');
+
+function loadTsModule(file) {
+  const src = fs.readFileSync(file, 'utf8');
+  const { outputText } = ts.transpileModule(src, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+    fileName: file,
+  });
+  const module = { exports: {} };
+  const req = (p) => {
+    if (p.startsWith('.') || p.startsWith('/')) {
+      const full = path.resolve(path.dirname(file), p);
+      const tsFile = full.endsWith('.ts') ? full : full + '.ts';
+      if (fs.existsSync(tsFile)) return loadTsModule(tsFile);
+      return require(full);
+    }
+    return require(p);
+  };
+  const fn = new Function('require', 'module', 'exports', outputText);
+  fn(req, module, module.exports);
+  return module.exports;
+}
+
+const { haversine } = loadTsModule(path.resolve(__dirname, '../src/logic/distance.ts'));
+const { findClosestStopByWalking } = loadTsModule(path.resolve(__dirname, '../src/logic/routing.ts'));
+
+test('fallback uses haversine distance', async () => {
+  const point = [0, 0];
+  const stops = [
+    [0, 0.01],
+    [0, 0.02],
+  ];
+  const result = await findClosestStopByWalking(point, stops, 0);
+  assert.ok(result);
+  const expected = haversine(point, stops[0]);
+  assert.ok(Math.abs(result.distanceMeters - expected) < 1e-6);
+});


### PR DESCRIPTION
## Summary
- compute fallback walking distance with haversine instead of degree difference
- add test ensuring fallback distance matches haversine formula
- ignore temporary build outputs

## Testing
- `npm run build`
- `node --test tests/routing.test.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c7b9ebb3a083229992f0b42951d8da